### PR TITLE
Fix: Extract gauge metrics in addMetricResult method

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
@@ -167,6 +167,10 @@ class DataflowMetrics extends MetricResults {
         // stringset metric
         StringSetResult value = getStringSetValue(committed);
         stringSetResults.add(MetricResult.create(metricKey, !isStreamingJob, value));
+      } else if (committed.getGauge() != null && attempted.getGauge() != null) {
+        // gauge metric
+        GaugeResult value = getGaugeValue(committed);
+        gaugeResults.add(MetricResult.create(metricKey, !isStreamingJob, value));
       } else {
         // This is exceptionally unexpected. We expect matching user metrics to only have the
         // value types provided by the Metrics API.


### PR DESCRIPTION
Added necessary logic in "addMetricResult" method to properly handle and extract gauge metrics from committed and attempted updates.

previously, gauge metrics were missing from the metrics result, which prevented customers from querying them programmatically in Dataflow jobs.

changes  done are

conditional block for Gauge metrics: Added a check to process and extract gauge metrics when both the committed.getGauge() and attempted.getGauge() values are not null.

ensured that the fix works for both streaming and batch Dataflow jobs by using the isStreamingJob flag.


This fix addresses the issue described in [#33448]